### PR TITLE
Version 5.2.1 - Implicit Import Fox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.2.1] - 2024-09-24
+
+### Changed
+
+- The line `from typing import *` in most templates to `import typing` and now 
+  references to classes an such from `typing` are explicit (i.e. `List` -> 
+  `typing.List`) 
+
+### Fixed
+
+- Side-effects caused by `from typing import *` when messages/classes share a 
+  name of classes in the `typing` package
+- Bug where `datetime` was missing from imports in gRPC senders and receivers
+
+
 ## [5.2.0] - 2024-09-23
 
 ### Added

--- a/neobuilder/__init__.py
+++ b/neobuilder/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '5.2.0'
+__version__ = '5.2.1'
 
 __author__ = 'Thordur Matthiasson <thordurm@ccpgames.com>'
 __license__ = 'MIT License'

--- a/neobuilder/data/templates/dataclass_module.jinja2
+++ b/neobuilder/data/templates/dataclass_module.jinja2
@@ -10,7 +10,7 @@ __all__ = [
 import dataclasses
 import datetime
 import enum
-from typing import *
+import typing
 from protoplasm.casting import dictators
 from protoplasm import plasm
 {{ imports }}

--- a/neobuilder/data/templates/grpc_receiver.jinja2
+++ b/neobuilder/data/templates/grpc_receiver.jinja2
@@ -6,10 +6,11 @@ __all__ = [
     '{{ a }}',
 {% endfor %}
 ]
-from typing import *
+import datetime
+import typing
 from protoplasm import plasm
 {{ imports }}
-if TYPE_CHECKING:
+if typing.TYPE_CHECKING:
     from grpc import ServicerContext
     {{ api_import }}
 

--- a/neobuilder/data/templates/grpc_sender.jinja2
+++ b/neobuilder/data/templates/grpc_sender.jinja2
@@ -7,10 +7,11 @@ __all__ = [
     '{{ a }}',
 {% endfor %}
 ]
-from typing import *
+import datetime
+import typing
 from protoplasm import plasm
 {{ imports }}
-if TYPE_CHECKING:
+if typing.TYPE_CHECKING:
     from grpc import ChannelCredentials
 
 import logging

--- a/neobuilder/data/templates/interface.jinja2
+++ b/neobuilder/data/templates/interface.jinja2
@@ -8,7 +8,7 @@ __all__ = [
 {% endfor %}
 ]
 import datetime
-from typing import *
+import typing
 from protoplasm import plasm
 
 {% for import_line in import_lines %}

--- a/neobuilder/descwrap/_field.py
+++ b/neobuilder/descwrap/_field.py
@@ -53,7 +53,7 @@ class FieldKind(enum.IntFlag):
     FIELD_ENUM_MAP = DATA_ENUM | KIND_MAP
 
     def __repr__(self) -> str:
-        return self.name
+        return self.name or str(self.value)
 
 
 @dataclasses.dataclass

--- a/neobuilder/generators/servicebuilders/grpc_sender.py
+++ b/neobuilder/generators/servicebuilders/grpc_sender.py
@@ -48,7 +48,7 @@ class ServiceBuilder(base.AbstractServiceBuilder):
         i = self.base_indent
         return (
             f'{i}class {self.service.service_descriptor.name}(plasm.BaseGrpcClientImplementation, {self.service.service_descriptor.name}Interface):\n'
-            f'{i}{__}def __init__(self, grpc_host: str = \'localhost:50051\', credentials: Optional[Union[bool, \'ChannelCredentials\']] = None, options: Optional[Dict] = None, *args, **kwargs):\n'
+            f'{i}{__}def __init__(self, grpc_host: str = \'localhost:50051\', credentials: typing.Optional[typing.Union[bool, \'ChannelCredentials\']] = None, options: typing.Optional[typing.Dict] = None, *args, **kwargs):\n'
             f'{i}{__}{__}super().__init__(pb2_grpc.{self.service.service_descriptor.name}Stub, grpc_host, credentials, options, *args, **kwargs)\n'
             f'\n'
             f'{self.render_methods()}'

--- a/neobuilder/generators/symbols/dataclass.py
+++ b/neobuilder/generators/symbols/dataclass.py
@@ -94,7 +94,7 @@ class ProtoClass(object):
 
     def output_google_type_proxy(self):
         return {
-            'Empty': 'NoReturn'
+            'Empty': 'typing.NoReturn'
         }.get(
             self.get_class_name()
         )
@@ -162,7 +162,7 @@ class ProtoClass(object):
             type_hint = f'{self.self_import.get_import_name(method_desc.file_descriptor)}.{self.descriptor.name}'
 
         if method_desc.io_type.is_input_stream():
-            return f', request_iterator: Iterable[{type_hint}]'
+            return f', request_iterator: typing.Iterable[{type_hint}]'
         return f', {self.get_under_name()}: {type_hint}'
 
     def render_forwarded_args(self):
@@ -179,8 +179,8 @@ class ProtoClass(object):
             if len(type_hint_list) == 1:
                 return type_hint_list[0]
             else:
-                return f"Tuple[{', '.join(type_hint_list)}]"
-        return 'NoReturn'
+                return f"typing.Tuple[{', '.join(type_hint_list)}]"
+        return 'typing.NoReturn'
 
     def render_api_return_dataclass(self, api_file: typing.Optional[pro_desc.FileDescriptor] = None):
         if self.descriptor.file.package == 'google.protobuf':
@@ -280,11 +280,11 @@ class ProtoField(object):
 
     def get_type_hint(self, used_in_file: json_format.descriptor.FileDescriptor = None) -> str:
         if self.is_struct():
-            return f'Dict[str, Any]'
+            return f'typing.Dict[str, typing.Any]'
         elif self.is_map():
-            return f'Dict[{self.field_descriptor.key_py_type.name}, {self.get_py_type_name(used_in_file)}]'
+            return f'typing.Dict[{self.field_descriptor.key_py_type.name}, {self.get_py_type_name(used_in_file)}]'
         elif self.is_list():
-            return f'List[{self.get_py_type_name(used_in_file)}]'
+            return f'typing.List[{self.get_py_type_name(used_in_file)}]'
         elif self.is_empty():
             return f'None'
         return self.get_py_type_name(used_in_file)

--- a/neobuilder/generators/symbols/service.py
+++ b/neobuilder/generators/symbols/service.py
@@ -114,7 +114,7 @@ class ProtoMethod(object):
     def get_request_type_hint(self) -> str:
         unary = f'{self.input.render_pb2_type_hint(self.service.module)}'
         if self.io_type.is_input_stream():
-            return f'Iterable[{unary}]'
+            return f'typing.Iterable[{unary}]'
         return unary
 
     def get_request_dc_type_hint(self) -> str:
@@ -125,7 +125,7 @@ class ProtoMethod(object):
 
     def get_response_dc_type(self) -> str:
         if self.io_type.is_output_stream():
-            return f'Iterable[{self.get_response_dc_class_type()}]'
+            return f'typing.Iterable[{self.get_response_dc_class_type()}]'
         return self.get_response_dc_class_type()
 
     def get_response_dc_class_type(self) -> str:

--- a/neobuilder/neobuilder/render/renderer.py
+++ b/neobuilder/neobuilder/render/renderer.py
@@ -43,14 +43,3 @@ class TemplateRenderer(metaclass=Singleton):
         except Exception as ex:
             log.exception(f'Error in template: {template_name}: {ex!r}')
             raise ex
-
-
-def main():
-    t = TemplateRenderer()
-    print(t.render_file('root_init',
-                        version='(3, 1, 0, 0)',
-                        protoplasm_version='(4, 0, 0, 0)'))
-
-
-if __name__ == '__main__':
-    main()

--- a/tests/res/expected/sandbox/test/alpha_dc.py
+++ b/tests/res/expected/sandbox/test/alpha_dc.py
@@ -9,7 +9,7 @@ __all__ = [
 import dataclasses
 import datetime
 import enum
-from typing import *
+import typing
 from protoplasm.casting import dictators
 from protoplasm import plasm
 

--- a/tests/res/expected/sandbox/test/anytest_dc.py
+++ b/tests/res/expected/sandbox/test/anytest_dc.py
@@ -9,7 +9,7 @@ __all__ = [
 import dataclasses
 import datetime
 import enum
-from typing import *
+import typing
 from protoplasm.casting import dictators
 from protoplasm import plasm
 
@@ -23,7 +23,7 @@ log = logging.getLogger(__name__)
 class AnyMessage(plasm.DataclassBase):
     __proto_cls__ = pb2.AnyMessage
     my_any: plasm.DataclassBase = dataclasses.field(default=None, metadata={'dictator': dictators.AnyDictator})
-    my_any_list: List[plasm.DataclassBase] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.AnyDictator, 'is_list': True})
-    my_any_map: Dict[str, plasm.DataclassBase] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.AnyDictator, 'is_map': True})
+    my_any_list: typing.List[plasm.DataclassBase] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.AnyDictator, 'is_list': True})
+    my_any_map: typing.Dict[str, plasm.DataclassBase] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.AnyDictator, 'is_map': True})
 
 

--- a/tests/res/expected/sandbox/test/beta_dc.py
+++ b/tests/res/expected/sandbox/test/beta_dc.py
@@ -9,7 +9,7 @@ __all__ = [
 import dataclasses
 import datetime
 import enum
-from typing import *
+import typing
 from protoplasm.casting import dictators
 from protoplasm import plasm
 from sandbox.test import alpha_dc as sandbox__test__alpha_dc

--- a/tests/res/expected/sandbox/test/clones_dc.py
+++ b/tests/res/expected/sandbox/test/clones_dc.py
@@ -11,7 +11,7 @@ __all__ = [
 import dataclasses
 import datetime
 import enum
-from typing import *
+import typing
 from protoplasm.casting import dictators
 from protoplasm import plasm
 

--- a/tests/res/expected/sandbox/test/delta_dc.py
+++ b/tests/res/expected/sandbox/test/delta_dc.py
@@ -9,7 +9,7 @@ __all__ = [
 import dataclasses
 import datetime
 import enum
-from typing import *
+import typing
 from protoplasm.casting import dictators
 from protoplasm import plasm
 from sandbox.test import beta_dc as sandbox__test__beta_dc

--- a/tests/res/expected/sandbox/test/enums_dc.py
+++ b/tests/res/expected/sandbox/test/enums_dc.py
@@ -13,7 +13,7 @@ __all__ = [
 import dataclasses
 import datetime
 import enum
-from typing import *
+import typing
 from protoplasm.casting import dictators
 from protoplasm import plasm
 
@@ -64,10 +64,10 @@ class WithExternalEnum(plasm.DataclassBase):
     __proto_cls__ = pb2.WithExternalEnum
     my_enum: ExternalEnum = dataclasses.field(default=0, metadata={'dictator': dictators.EnumDictator, 'is_enum': True})
     my_alias_enum: ExternalAliasEnum = dataclasses.field(default=0, metadata={'dictator': dictators.EnumDictator, 'is_enum': True})
-    my_enum_list: List[ExternalEnum] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.EnumDictator, 'is_list': True, 'is_enum': True})
-    my_alias_enum_list: List[ExternalAliasEnum] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.EnumDictator, 'is_list': True, 'is_enum': True})
-    my_enum_map: Dict[str, ExternalEnum] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.EnumDictator, 'is_map': True, 'is_enum': True})
-    my_alias_enum_map: Dict[str, ExternalAliasEnum] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.EnumDictator, 'is_map': True, 'is_enum': True})
+    my_enum_list: typing.List[ExternalEnum] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.EnumDictator, 'is_list': True, 'is_enum': True})
+    my_alias_enum_list: typing.List[ExternalAliasEnum] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.EnumDictator, 'is_list': True, 'is_enum': True})
+    my_enum_map: typing.Dict[str, ExternalEnum] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.EnumDictator, 'is_map': True, 'is_enum': True})
+    my_alias_enum_map: typing.Dict[str, ExternalAliasEnum] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.EnumDictator, 'is_map': True, 'is_enum': True})
 
 
 @dataclasses.dataclass
@@ -108,10 +108,10 @@ class WithInternalEnum(plasm.DataclassBase):
 
     my_internal_enum: WithInternalEnum.InternalEnum = dataclasses.field(default=0, metadata={'dictator': dictators.EnumDictator, 'is_enum': True})
     my_internal_alias_enum: WithInternalEnum.InternalAliasEnum = dataclasses.field(default=0, metadata={'dictator': dictators.EnumDictator, 'is_enum': True})
-    my_internal_enum_list: List[WithInternalEnum.InternalEnum] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.EnumDictator, 'is_list': True, 'is_enum': True})
-    my_internal_alias_enum_list: List[WithInternalEnum.InternalAliasEnum] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.EnumDictator, 'is_list': True, 'is_enum': True})
-    my_internal_enum_map: Dict[str, WithInternalEnum.InternalEnum] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.EnumDictator, 'is_map': True, 'is_enum': True})
-    my_internal_alias_enum_map: Dict[str, WithInternalEnum.InternalAliasEnum] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.EnumDictator, 'is_map': True, 'is_enum': True})
+    my_internal_enum_list: typing.List[WithInternalEnum.InternalEnum] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.EnumDictator, 'is_list': True, 'is_enum': True})
+    my_internal_alias_enum_list: typing.List[WithInternalEnum.InternalAliasEnum] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.EnumDictator, 'is_list': True, 'is_enum': True})
+    my_internal_enum_map: typing.Dict[str, WithInternalEnum.InternalEnum] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.EnumDictator, 'is_map': True, 'is_enum': True})
+    my_internal_alias_enum_map: typing.Dict[str, WithInternalEnum.InternalAliasEnum] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.EnumDictator, 'is_map': True, 'is_enum': True})
 
 
 @dataclasses.dataclass

--- a/tests/res/expected/sandbox/test/googlestruct_dc.py
+++ b/tests/res/expected/sandbox/test/googlestruct_dc.py
@@ -9,7 +9,7 @@ __all__ = [
 import dataclasses
 import datetime
 import enum
-from typing import *
+import typing
 from protoplasm.casting import dictators
 from protoplasm import plasm
 
@@ -22,5 +22,5 @@ log = logging.getLogger(__name__)
 @dataclasses.dataclass
 class StructMessage(plasm.DataclassBase):
     __proto_cls__ = pb2.StructMessage
-    my_struct: Dict[str, Any] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.StructDictator, 'is_struct': True})
+    my_struct: typing.Dict[str, typing.Any] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.StructDictator, 'is_struct': True})
 

--- a/tests/res/expected/sandbox/test/illnamedfields_dc.py
+++ b/tests/res/expected/sandbox/test/illnamedfields_dc.py
@@ -9,7 +9,7 @@ __all__ = [
 import dataclasses
 import datetime
 import enum
-from typing import *
+import typing
 from protoplasm.casting import dictators
 from protoplasm import plasm
 

--- a/tests/res/expected/sandbox/test/illnamedservice_api.py
+++ b/tests/res/expected/sandbox/test/illnamedservice_api.py
@@ -6,7 +6,7 @@ __all__ = [
     'ServiceWithBadRequestNamesInterface',
 ]
 import datetime
-from typing import *
+import typing
 from protoplasm import plasm
 
 from sandbox.test import illnamedservice_dc as dc

--- a/tests/res/expected/sandbox/test/illnamedservice_dc.py
+++ b/tests/res/expected/sandbox/test/illnamedservice_dc.py
@@ -10,7 +10,7 @@ __all__ = [
 import dataclasses
 import datetime
 import enum
-from typing import *
+import typing
 from protoplasm.casting import dictators
 from protoplasm import plasm
 

--- a/tests/res/expected/sandbox/test/illnamedservice_grpc_receiver.py
+++ b/tests/res/expected/sandbox/test/illnamedservice_grpc_receiver.py
@@ -5,12 +5,13 @@
 __all__ = [
     'ServiceWithBadRequestNamesGrpcServicer',
 ]
-from typing import *
+import datetime
+import typing
 from protoplasm import plasm
 from sandbox.test import illnamedservice_dc as dc
 from sandbox.test import illnamedservice_pb2 as pb2
 from sandbox.test import illnamedservice_pb2_grpc as pb2_grpc
-if TYPE_CHECKING:
+if typing.TYPE_CHECKING:
     from grpc import ServicerContext
     from sandbox.test import illnamedservice_api as api
 

--- a/tests/res/expected/sandbox/test/illnamedservice_grpc_sender.py
+++ b/tests/res/expected/sandbox/test/illnamedservice_grpc_sender.py
@@ -6,13 +6,14 @@ from __future__ import annotations
 __all__ = [
     'ServiceWithBadRequestNames',
 ]
-from typing import *
+import datetime
+import typing
 from protoplasm import plasm
 from sandbox.test import illnamedservice_dc as dc
 from sandbox.test import illnamedservice_pb2_grpc as pb2_grpc
 from sandbox.test.illnamedservice_api import *
 
-if TYPE_CHECKING:
+if typing.TYPE_CHECKING:
     from grpc import ChannelCredentials
 
 import logging
@@ -20,7 +21,7 @@ log = logging.getLogger(__name__)
 
 
 class ServiceWithBadRequestNames(plasm.BaseGrpcClientImplementation, ServiceWithBadRequestNamesInterface):
-    def __init__(self, grpc_host: str = 'localhost:50051', credentials: Optional[Union[bool, 'ChannelCredentials']] = None, options: Optional[Dict] = None, *args, **kwargs):
+    def __init__(self, grpc_host: str = 'localhost:50051', credentials: typing.Optional[typing.Union[bool, 'ChannelCredentials']] = None, options: typing.Optional[typing.Dict] = None, *args, **kwargs):
         super().__init__(pb2_grpc.ServiceWithBadRequestNamesStub, grpc_host, credentials, options, *args, **kwargs)
 
     def do_something(self, foo: str = None) -> str:

--- a/tests/res/expected/sandbox/test/imported_enum_dc.py
+++ b/tests/res/expected/sandbox/test/imported_enum_dc.py
@@ -9,7 +9,7 @@ __all__ = [
 import dataclasses
 import datetime
 import enum
-from typing import *
+import typing
 from protoplasm.casting import dictators
 from protoplasm import plasm
 from sandbox.test import enums_dc as sandbox__test__enums_dc

--- a/tests/res/expected/sandbox/test/interfaceonly_api.py
+++ b/tests/res/expected/sandbox/test/interfaceonly_api.py
@@ -6,7 +6,7 @@ __all__ = [
     'InterfaceOnlyServiceInterface',
 ]
 import datetime
-from typing import *
+import typing
 from protoplasm import plasm
 
 from sandbox.test import interfaceonly_dc as dc

--- a/tests/res/expected/sandbox/test/interfaceonly_dc.py
+++ b/tests/res/expected/sandbox/test/interfaceonly_dc.py
@@ -10,7 +10,7 @@ __all__ = [
 import dataclasses
 import datetime
 import enum
-from typing import *
+import typing
 from protoplasm.casting import dictators
 from protoplasm import plasm
 

--- a/tests/res/expected/sandbox/test/nested_dc.py
+++ b/tests/res/expected/sandbox/test/nested_dc.py
@@ -9,7 +9,7 @@ __all__ = [
 import dataclasses
 import datetime
 import enum
-from typing import *
+import typing
 from protoplasm.casting import dictators
 from protoplasm import plasm
 

--- a/tests/res/expected/sandbox/test/rainbow_dc.py
+++ b/tests/res/expected/sandbox/test/rainbow_dc.py
@@ -16,7 +16,7 @@ __all__ = [
 import dataclasses
 import datetime
 import enum
-from typing import *
+import typing
 from protoplasm.casting import dictators
 from protoplasm import plasm
 
@@ -38,26 +38,26 @@ class RainbowMessage(plasm.DataclassBase):
     __proto_cls__ = pb2.RainbowMessage
     simple_field: str = dataclasses.field(default='', metadata={'dictator': dictators.BaseDictator})
     message_field: SubMessage = dataclasses.field(default=None, metadata={'dictator': dictators.BaseDictator, 'is_obj': True})
-    simple_list: List[str] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.BaseDictator, 'is_list': True})
-    message_list: List[SubMessage] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.BaseDictator, 'is_list': True, 'is_obj': True})
-    simple_map: Dict[str, str] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True})
-    message_map: Dict[str, SubMessage] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True, 'is_obj': True})
+    simple_list: typing.List[str] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.BaseDictator, 'is_list': True})
+    message_list: typing.List[SubMessage] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.BaseDictator, 'is_list': True, 'is_obj': True})
+    simple_map: typing.Dict[str, str] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True})
+    message_map: typing.Dict[str, SubMessage] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True, 'is_obj': True})
 
 
 @dataclasses.dataclass
 class TimestampMessage(plasm.DataclassBase):
     __proto_cls__ = pb2.TimestampMessage
     my_timestamp: datetime.datetime = dataclasses.field(default=None, metadata={'dictator': dictators.TimestampDictator})
-    my_timestamp_list: List[datetime.datetime] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.TimestampDictator, 'is_list': True})
-    my_timestamp_map: Dict[str, datetime.datetime] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.TimestampDictator, 'is_map': True})
+    my_timestamp_list: typing.List[datetime.datetime] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.TimestampDictator, 'is_list': True})
+    my_timestamp_map: typing.Dict[str, datetime.datetime] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.TimestampDictator, 'is_map': True})
 
 
 @dataclasses.dataclass
 class BytesMessage(plasm.DataclassBase):
     __proto_cls__ = pb2.BytesMessage
     my_bytes: bytes = dataclasses.field(default=b'', metadata={'dictator': dictators.ByteDictator})
-    my_bytes_list: List[bytes] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.ByteDictator, 'is_list': True})
-    my_bytes_map: Dict[str, bytes] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.ByteDictator, 'is_map': True})
+    my_bytes_list: typing.List[bytes] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.ByteDictator, 'is_list': True})
+    my_bytes_map: typing.Dict[str, bytes] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.ByteDictator, 'is_map': True})
 
 
 @dataclasses.dataclass
@@ -83,54 +83,54 @@ class AllTypes(plasm.DataclassBase):
 @dataclasses.dataclass
 class AllTypesList(plasm.DataclassBase):
     __proto_cls__ = pb2.AllTypesList
-    my_string_list: List[str] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.BaseDictator, 'is_list': True})
-    my_float_list: List[float] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.BaseDictator, 'is_list': True})
-    my_double_list: List[float] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.BaseDictator, 'is_list': True})
-    my_int32_list: List[int] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.BaseDictator, 'is_list': True})
-    my_int64_list: List[int] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.LongDictator, 'is_list': True})
-    my_uint32_list: List[int] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.BaseDictator, 'is_list': True})
-    my_uint64_list: List[int] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.LongDictator, 'is_list': True})
-    my_sint32_list: List[int] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.BaseDictator, 'is_list': True})
-    my_sint64_list: List[int] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.LongDictator, 'is_list': True})
-    my_fixed32_list: List[int] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.BaseDictator, 'is_list': True})
-    my_fixed64_list: List[int] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.LongDictator, 'is_list': True})
-    my_sfixed32_list: List[int] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.BaseDictator, 'is_list': True})
-    my_sfixed64_list: List[int] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.LongDictator, 'is_list': True})
-    my_bool_list: List[bool] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.BaseDictator, 'is_list': True})
-    my_bytes_list: List[bytes] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.ByteDictator, 'is_list': True})
+    my_string_list: typing.List[str] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.BaseDictator, 'is_list': True})
+    my_float_list: typing.List[float] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.BaseDictator, 'is_list': True})
+    my_double_list: typing.List[float] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.BaseDictator, 'is_list': True})
+    my_int32_list: typing.List[int] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.BaseDictator, 'is_list': True})
+    my_int64_list: typing.List[int] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.LongDictator, 'is_list': True})
+    my_uint32_list: typing.List[int] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.BaseDictator, 'is_list': True})
+    my_uint64_list: typing.List[int] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.LongDictator, 'is_list': True})
+    my_sint32_list: typing.List[int] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.BaseDictator, 'is_list': True})
+    my_sint64_list: typing.List[int] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.LongDictator, 'is_list': True})
+    my_fixed32_list: typing.List[int] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.BaseDictator, 'is_list': True})
+    my_fixed64_list: typing.List[int] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.LongDictator, 'is_list': True})
+    my_sfixed32_list: typing.List[int] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.BaseDictator, 'is_list': True})
+    my_sfixed64_list: typing.List[int] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.LongDictator, 'is_list': True})
+    my_bool_list: typing.List[bool] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.BaseDictator, 'is_list': True})
+    my_bytes_list: typing.List[bytes] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.ByteDictator, 'is_list': True})
 
 
 @dataclasses.dataclass
 class AllTypesMap(plasm.DataclassBase):
     __proto_cls__ = pb2.AllTypesMap
-    my_string_map: Dict[str, str] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True})
-    my_int32_map: Dict[int, int] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True})
-    my_int64_map: Dict[int, int] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.LongDictator, 'is_map': True})
-    my_uint32_map: Dict[int, int] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True})
-    my_uint64_map: Dict[int, int] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.LongDictator, 'is_map': True})
-    my_sint32_map: Dict[int, int] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True})
-    my_sint64_map: Dict[int, int] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.LongDictator, 'is_map': True})
-    my_fixed32_map: Dict[int, int] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True})
-    my_fixed64_map: Dict[int, int] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.LongDictator, 'is_map': True})
-    my_sfixed32_map: Dict[int, int] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True})
-    my_sfixed64_map: Dict[int, int] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.LongDictator, 'is_map': True})
-    my_bool_map: Dict[bool, bool] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True})
+    my_string_map: typing.Dict[str, str] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True})
+    my_int32_map: typing.Dict[int, int] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True})
+    my_int64_map: typing.Dict[int, int] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.LongDictator, 'is_map': True})
+    my_uint32_map: typing.Dict[int, int] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True})
+    my_uint64_map: typing.Dict[int, int] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.LongDictator, 'is_map': True})
+    my_sint32_map: typing.Dict[int, int] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True})
+    my_sint64_map: typing.Dict[int, int] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.LongDictator, 'is_map': True})
+    my_fixed32_map: typing.Dict[int, int] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True})
+    my_fixed64_map: typing.Dict[int, int] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.LongDictator, 'is_map': True})
+    my_sfixed32_map: typing.Dict[int, int] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True})
+    my_sfixed64_map: typing.Dict[int, int] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.LongDictator, 'is_map': True})
+    my_bool_map: typing.Dict[bool, bool] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True})
 
 
 @dataclasses.dataclass
 class AllTypesNestedMap(plasm.DataclassBase):
     __proto_cls__ = pb2.AllTypesNestedMap
-    my_string_map: Dict[str, SubMessage] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True, 'is_obj': True})
-    my_int32_map: Dict[int, SubMessage] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True, 'is_obj': True})
-    my_int64_map: Dict[int, SubMessage] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True, 'is_obj': True})
-    my_uint32_map: Dict[int, SubMessage] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True, 'is_obj': True})
-    my_uint64_map: Dict[int, SubMessage] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True, 'is_obj': True})
-    my_sint32_map: Dict[int, SubMessage] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True, 'is_obj': True})
-    my_sint64_map: Dict[int, SubMessage] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True, 'is_obj': True})
-    my_fixed32_map: Dict[int, SubMessage] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True, 'is_obj': True})
-    my_fixed64_map: Dict[int, SubMessage] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True, 'is_obj': True})
-    my_sfixed32_map: Dict[int, SubMessage] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True, 'is_obj': True})
-    my_sfixed64_map: Dict[int, SubMessage] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True, 'is_obj': True})
-    my_bool_map: Dict[bool, SubMessage] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True, 'is_obj': True})
+    my_string_map: typing.Dict[str, SubMessage] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True, 'is_obj': True})
+    my_int32_map: typing.Dict[int, SubMessage] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True, 'is_obj': True})
+    my_int64_map: typing.Dict[int, SubMessage] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True, 'is_obj': True})
+    my_uint32_map: typing.Dict[int, SubMessage] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True, 'is_obj': True})
+    my_uint64_map: typing.Dict[int, SubMessage] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True, 'is_obj': True})
+    my_sint32_map: typing.Dict[int, SubMessage] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True, 'is_obj': True})
+    my_sint64_map: typing.Dict[int, SubMessage] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True, 'is_obj': True})
+    my_fixed32_map: typing.Dict[int, SubMessage] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True, 'is_obj': True})
+    my_fixed64_map: typing.Dict[int, SubMessage] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True, 'is_obj': True})
+    my_sfixed32_map: typing.Dict[int, SubMessage] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True, 'is_obj': True})
+    my_sfixed64_map: typing.Dict[int, SubMessage] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True, 'is_obj': True})
+    my_bool_map: typing.Dict[bool, SubMessage] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True, 'is_obj': True})
 
 

--- a/tests/res/expected/sandbox/test/river_api.py
+++ b/tests/res/expected/sandbox/test/river_api.py
@@ -6,7 +6,7 @@ __all__ = [
     'StreamingServiceInterface',
 ]
 import datetime
-from typing import *
+import typing
 from protoplasm import plasm
 
 from sandbox.test import river_dc as dc
@@ -22,12 +22,12 @@ class StreamingServiceInterface:
     def reverse_my_shit(self, shit: str = None) -> str:
         raise plasm.Unimplemented()
 
-    def marco_polo(self, request_iterator: Iterable[dc.MarcoPoloRequest]) -> plasm.ResponseIterator[dc.MarcoPoloResponse]:
+    def marco_polo(self, request_iterator: typing.Iterable[dc.MarcoPoloRequest]) -> plasm.ResponseIterator[dc.MarcoPoloResponse]:
         raise plasm.Unimplemented()
 
     def tell_me_a_story(self, story: str = None) -> plasm.ResponseIterator[dc.TellMeAStoryResponse]:
         raise plasm.Unimplemented()
 
-    def guess_the_number(self, request_iterator: Iterable[dc.GuessTheNumberRequest]) -> str:
+    def guess_the_number(self, request_iterator: typing.Iterable[dc.GuessTheNumberRequest]) -> str:
         raise plasm.Unimplemented()
 

--- a/tests/res/expected/sandbox/test/river_dc.py
+++ b/tests/res/expected/sandbox/test/river_dc.py
@@ -16,7 +16,7 @@ __all__ = [
 import dataclasses
 import datetime
 import enum
-from typing import *
+import typing
 from protoplasm.casting import dictators
 from protoplasm import plasm
 

--- a/tests/res/expected/sandbox/test/river_grpc_receiver.py
+++ b/tests/res/expected/sandbox/test/river_grpc_receiver.py
@@ -5,12 +5,13 @@
 __all__ = [
     'StreamingServiceGrpcServicer',
 ]
-from typing import *
+import datetime
+import typing
 from protoplasm import plasm
 from sandbox.test import river_dc as dc
 from sandbox.test import river_pb2 as pb2
 from sandbox.test import river_pb2_grpc as pb2_grpc
-if TYPE_CHECKING:
+if typing.TYPE_CHECKING:
     from grpc import ServicerContext
     from sandbox.test import river_api as api
 
@@ -28,12 +29,12 @@ class StreamingServiceGrpcServicer(plasm.BaseGrpcServicer, pb2_grpc.StreamingSer
     def ReverseMyShit(self, request: dc.pb2.ReverseMyShitRequest, context: 'ServicerContext') -> dc.pb2.ReverseMyShitResponse:
         return self._forward_to_unary_unary_impl(dc.ReverseMyShitResponse, self.impl.reverse_my_shit, request, context)
 
-    def MarcoPolo(self, request_iterator: Iterable[dc.pb2.MarcoPoloRequest], context: 'ServicerContext') -> dc.pb2.MarcoPoloResponse:
+    def MarcoPolo(self, request_iterator: typing.Iterable[dc.pb2.MarcoPoloRequest], context: 'ServicerContext') -> dc.pb2.MarcoPoloResponse:
         return self._forward_to_stream_stream_impl(dc.MarcoPoloResponse, self.impl.marco_polo, request_iterator, context)
 
     def TellMeAStory(self, request: dc.pb2.TellMeAStoryRequest, context: 'ServicerContext') -> dc.pb2.TellMeAStoryResponse:
         return self._forward_to_unary_stream_impl(dc.TellMeAStoryResponse, self.impl.tell_me_a_story, request, context)
 
-    def GuessTheNumber(self, request_iterator: Iterable[dc.pb2.GuessTheNumberRequest], context: 'ServicerContext') -> dc.pb2.GuessTheNumberResponse:
+    def GuessTheNumber(self, request_iterator: typing.Iterable[dc.pb2.GuessTheNumberRequest], context: 'ServicerContext') -> dc.pb2.GuessTheNumberResponse:
         return self._forward_to_stream_unary_impl(dc.GuessTheNumberResponse, self.impl.guess_the_number, request_iterator, context)
 

--- a/tests/res/expected/sandbox/test/river_grpc_sender.py
+++ b/tests/res/expected/sandbox/test/river_grpc_sender.py
@@ -6,13 +6,14 @@ from __future__ import annotations
 __all__ = [
     'StreamingService',
 ]
-from typing import *
+import datetime
+import typing
 from protoplasm import plasm
 from sandbox.test import river_dc as dc
 from sandbox.test import river_pb2_grpc as pb2_grpc
 from sandbox.test.river_api import *
 
-if TYPE_CHECKING:
+if typing.TYPE_CHECKING:
     from grpc import ChannelCredentials
 
 import logging
@@ -20,17 +21,17 @@ log = logging.getLogger(__name__)
 
 
 class StreamingService(plasm.BaseGrpcClientImplementation, StreamingServiceInterface):
-    def __init__(self, grpc_host: str = 'localhost:50051', credentials: Optional[Union[bool, 'ChannelCredentials']] = None, options: Optional[Dict] = None, *args, **kwargs):
+    def __init__(self, grpc_host: str = 'localhost:50051', credentials: typing.Optional[typing.Union[bool, 'ChannelCredentials']] = None, options: typing.Optional[typing.Dict] = None, *args, **kwargs):
         super().__init__(pb2_grpc.StreamingServiceStub, grpc_host, credentials, options, *args, **kwargs)
 
     def reverse_my_shit(self, shit: str = None) -> str:
         return self._forward_to_grpc(dc.ReverseMyShitRequest, self.stub.ReverseMyShit, shit)
 
-    def marco_polo(self, request_iterator: Iterable[dc.MarcoPoloRequest]) -> plasm.ResponseIterator[dc.MarcoPoloResponse]:
+    def marco_polo(self, request_iterator: typing.Iterable[dc.MarcoPoloRequest]) -> plasm.ResponseIterator[dc.MarcoPoloResponse]:
         return self._forward_to_grpc(dc.MarcoPoloRequest, self.stub.MarcoPolo, request_iterator)
 
     def tell_me_a_story(self, story: str = None) -> plasm.ResponseIterator[dc.TellMeAStoryResponse]:
         return self._forward_to_grpc(dc.TellMeAStoryRequest, self.stub.TellMeAStory, story)
 
-    def guess_the_number(self, request_iterator: Iterable[dc.GuessTheNumberRequest]) -> str:
+    def guess_the_number(self, request_iterator: typing.Iterable[dc.GuessTheNumberRequest]) -> str:
         return self._forward_to_grpc(dc.GuessTheNumberRequest, self.stub.GuessTheNumber, request_iterator)

--- a/tests/res/expected/sandbox/test/service_api.py
+++ b/tests/res/expected/sandbox/test/service_api.py
@@ -7,7 +7,7 @@ __all__ = [
     'MathInterface',
 ]
 import datetime
-from typing import *
+import typing
 from protoplasm import plasm
 
 from sandbox.test import service_dc as dc
@@ -27,7 +27,7 @@ class SimpleServiceInterface:
     def nested_hello(self, my_message: dc.GreetingMessage = None) -> dc.GreetingMessage:
         raise plasm.Unimplemented()
 
-    def empty_hello(self) -> NoReturn:
+    def empty_hello(self) -> typing.NoReturn:
         raise plasm.Unimplemented()
 
 
@@ -40,6 +40,6 @@ class MathInterface:
     def subtract(self, x: int = None, y: int = None) -> int:
         raise plasm.Unimplemented()
 
-    def integer_division(self, x: int = None, y: int = None) -> Tuple[int, int]:
+    def integer_division(self, x: int = None, y: int = None) -> typing.Tuple[int, int]:
         raise plasm.Unimplemented()
 

--- a/tests/res/expected/sandbox/test/service_dc.py
+++ b/tests/res/expected/sandbox/test/service_dc.py
@@ -21,7 +21,7 @@ __all__ = [
 import dataclasses
 import datetime
 import enum
-from typing import *
+import typing
 from protoplasm.casting import dictators
 from protoplasm import plasm
 

--- a/tests/res/expected/sandbox/test/service_grpc_receiver.py
+++ b/tests/res/expected/sandbox/test/service_grpc_receiver.py
@@ -6,13 +6,14 @@ __all__ = [
     'SimpleServiceGrpcServicer',
     'MathGrpcServicer',
 ]
-from typing import *
+import datetime
+import typing
 from protoplasm import plasm
 
 from sandbox.test import service_dc as dc
 from sandbox.test import service_pb2 as pb2
 from sandbox.test import service_pb2_grpc as pb2_grpc
-if TYPE_CHECKING:
+if typing.TYPE_CHECKING:
     from grpc import ServicerContext
     from sandbox.test import service_api as api
 

--- a/tests/res/expected/sandbox/test/service_grpc_sender.py
+++ b/tests/res/expected/sandbox/test/service_grpc_sender.py
@@ -7,13 +7,14 @@ __all__ = [
     'SimpleService',
     'Math',
 ]
-from typing import *
+import datetime
+import typing
 from protoplasm import plasm
 from sandbox.test import service_dc as dc
 from sandbox.test import service_pb2_grpc as pb2_grpc
 from sandbox.test.service_api import *
 
-if TYPE_CHECKING:
+if typing.TYPE_CHECKING:
     from grpc import ChannelCredentials
 
 import logging
@@ -21,7 +22,7 @@ log = logging.getLogger(__name__)
 
 
 class SimpleService(plasm.BaseGrpcClientImplementation, SimpleServiceInterface):
-    def __init__(self, grpc_host: str = 'localhost:50051', credentials: Optional[Union[bool, 'ChannelCredentials']] = None, options: Optional[Dict] = None, *args, **kwargs):
+    def __init__(self, grpc_host: str = 'localhost:50051', credentials: typing.Optional[typing.Union[bool, 'ChannelCredentials']] = None, options: typing.Optional[typing.Dict] = None, *args, **kwargs):
         super().__init__(pb2_grpc.SimpleServiceStub, grpc_host, credentials, options, *args, **kwargs)
 
     def hello(self, greeting: str = None) -> str:
@@ -30,11 +31,11 @@ class SimpleService(plasm.BaseGrpcClientImplementation, SimpleServiceInterface):
     def nested_hello(self, my_message: dc.GreetingMessage = None) -> dc.GreetingMessage:
         return self._forward_to_grpc(dc.NestedHelloRequest, self.stub.NestedHello, my_message)
 
-    def empty_hello(self) -> NoReturn:
+    def empty_hello(self) -> typing.NoReturn:
         return self._forward_to_grpc(dc.EmptyHelloRequest, self.stub.EmptyHello)
 
 class Math(plasm.BaseGrpcClientImplementation, MathInterface):
-    def __init__(self, grpc_host: str = 'localhost:50051', credentials: Optional[Union[bool, 'ChannelCredentials']] = None, options: Optional[Dict] = None, *args, **kwargs):
+    def __init__(self, grpc_host: str = 'localhost:50051', credentials: typing.Optional[typing.Union[bool, 'ChannelCredentials']] = None, options: typing.Optional[typing.Dict] = None, *args, **kwargs):
         super().__init__(pb2_grpc.MathStub, grpc_host, credentials, options, *args, **kwargs)
 
     def add(self, x: int = None, y: int = None) -> int:
@@ -43,5 +44,5 @@ class Math(plasm.BaseGrpcClientImplementation, MathInterface):
     def subtract(self, x: int = None, y: int = None) -> int:
         return self._forward_to_grpc(dc.SubtractRequest, self.stub.Subtract, x, y)
 
-    def integer_division(self, x: int = None, y: int = None) -> Tuple[int, int]:
+    def integer_division(self, x: int = None, y: int = None) -> typing.Tuple[int, int]:
         return self._forward_to_grpc(dc.IntegerDivisionRequest, self.stub.IntegerDivision, x, y)

--- a/tests/res/expected/sandbox/test/service_with_imported_io_api.py
+++ b/tests/res/expected/sandbox/test/service_with_imported_io_api.py
@@ -6,7 +6,7 @@ __all__ = [
     'ServiceWithImportedInputAndOutputInterface',
 ]
 import datetime
-from typing import *
+import typing
 from protoplasm import plasm
 
 from sandbox.test import alpha_dc as sandbox__test__alpha_dc
@@ -24,24 +24,24 @@ log = logging.getLogger(__name__)
 class ServiceWithImportedInputAndOutputInterface:
     __servicer_cls__ = ServiceWithImportedInputAndOutputGrpcServicer
 
-    def simple(self, my_string: str = None, my_number: int = None, my_level_three_message: sandbox__test__beta_dc.BetaMessage = None) -> Tuple[str, str]:
+    def simple(self, my_string: str = None, my_number: int = None, my_level_three_message: sandbox__test__beta_dc.BetaMessage = None) -> typing.Tuple[str, str]:
         raise plasm.Unimplemented()
 
-    def nested(self, simple_field: str = None, message_field: sandbox__test__rainbow_dc.SubMessage = None, simple_list: List[str] = None, message_list: List[sandbox__test__rainbow_dc.SubMessage] = None, simple_map: Dict[str, str] = None, message_map: Dict[str, sandbox__test__rainbow_dc.SubMessage] = None) -> Tuple[str, int, sandbox__test__alpha_dc.AlphaMessage]:
+    def nested(self, simple_field: str = None, message_field: sandbox__test__rainbow_dc.SubMessage = None, simple_list: typing.List[str] = None, message_list: typing.List[sandbox__test__rainbow_dc.SubMessage] = None, simple_map: typing.Dict[str, str] = None, message_map: typing.Dict[str, sandbox__test__rainbow_dc.SubMessage] = None) -> typing.Tuple[str, int, sandbox__test__alpha_dc.AlphaMessage]:
         raise plasm.Unimplemented()
 
-    def renest(self, my_int: int = None, my_string: str = None, my_message: sandbox__test__nested_dc.OuterMessage.InnerMessage = None) -> Tuple[str, str]:
+    def renest(self, my_int: int = None, my_string: str = None, my_message: sandbox__test__nested_dc.OuterMessage.InnerMessage = None) -> typing.Tuple[str, str]:
         raise plasm.Unimplemented()
 
-    def timestamp_in(self, my_timestamp: datetime.datetime = None, my_timestamp_list: List[datetime.datetime] = None, my_timestamp_map: Dict[str, datetime.datetime] = None) -> Tuple[str, int]:
+    def timestamp_in(self, my_timestamp: datetime.datetime = None, my_timestamp_list: typing.List[datetime.datetime] = None, my_timestamp_map: typing.Dict[str, datetime.datetime] = None) -> typing.Tuple[str, int]:
         raise plasm.Unimplemented()
 
-    def timestamp_out(self, my_string: str = None, my_number: int = None) -> Tuple[int, int]:
+    def timestamp_out(self, my_string: str = None, my_number: int = None) -> typing.Tuple[int, int]:
         raise plasm.Unimplemented()
 
-    def any_in(self, type_url: str = None, value: bytes = None) -> Tuple[str, int]:
+    def any_in(self, type_url: str = None, value: bytes = None) -> typing.Tuple[str, int]:
         raise plasm.Unimplemented()
 
-    def any_out(self, my_string: str = None, my_number: int = None) -> Tuple[str, bytes]:
+    def any_out(self, my_string: str = None, my_number: int = None) -> typing.Tuple[str, bytes]:
         raise plasm.Unimplemented()
 

--- a/tests/res/expected/sandbox/test/service_with_imported_io_dc.py
+++ b/tests/res/expected/sandbox/test/service_with_imported_io_dc.py
@@ -8,7 +8,7 @@ __all__ = [
 import dataclasses
 import datetime
 import enum
-from typing import *
+import typing
 from protoplasm.casting import dictators
 from protoplasm import plasm
 

--- a/tests/res/expected/sandbox/test/service_with_imported_io_grpc_receiver.py
+++ b/tests/res/expected/sandbox/test/service_with_imported_io_grpc_receiver.py
@@ -5,7 +5,8 @@
 __all__ = [
     'ServiceWithImportedInputAndOutputGrpcServicer',
 ]
-from typing import *
+import datetime
+import typing
 from protoplasm import plasm
 from google.protobuf import any_pb2
 from google.protobuf import timestamp_pb2
@@ -17,7 +18,7 @@ from sandbox.test import rainbow_dc as sandbox__test__rainbow_dc
 from sandbox.test import service_with_imported_io_dc as dc
 from sandbox.test import service_with_imported_io_pb2 as pb2
 from sandbox.test import service_with_imported_io_pb2_grpc as pb2_grpc
-if TYPE_CHECKING:
+if typing.TYPE_CHECKING:
     from grpc import ServicerContext
     from sandbox.test import service_with_imported_io_api as api
 

--- a/tests/res/expected/sandbox/test/service_with_imported_io_grpc_sender.py
+++ b/tests/res/expected/sandbox/test/service_with_imported_io_grpc_sender.py
@@ -6,7 +6,8 @@ from __future__ import annotations
 __all__ = [
     'ServiceWithImportedInputAndOutput',
 ]
-from typing import *
+import datetime
+import typing
 from protoplasm import plasm
 from sandbox.test import alpha_dc as sandbox__test__alpha_dc
 from sandbox.test import delta_dc as sandbox__test__delta_dc
@@ -15,7 +16,7 @@ from sandbox.test import rainbow_dc as sandbox__test__rainbow_dc
 from sandbox.test import service_with_imported_io_pb2_grpc as pb2_grpc
 from sandbox.test.service_with_imported_io_api import *
 
-if TYPE_CHECKING:
+if typing.TYPE_CHECKING:
     from grpc import ChannelCredentials
 
 import logging
@@ -23,26 +24,26 @@ log = logging.getLogger(__name__)
 
 
 class ServiceWithImportedInputAndOutput(plasm.BaseGrpcClientImplementation, ServiceWithImportedInputAndOutputInterface):
-    def __init__(self, grpc_host: str = 'localhost:50051', credentials: Optional[Union[bool, 'ChannelCredentials']] = None, options: Optional[Dict] = None, *args, **kwargs):
+    def __init__(self, grpc_host: str = 'localhost:50051', credentials: typing.Optional[typing.Union[bool, 'ChannelCredentials']] = None, options: typing.Optional[typing.Dict] = None, *args, **kwargs):
         super().__init__(pb2_grpc.ServiceWithImportedInputAndOutputStub, grpc_host, credentials, options, *args, **kwargs)
 
-    def simple(self, my_string: str = None, my_number: int = None, my_level_three_message: sandbox__test__beta_dc.BetaMessage = None) -> Tuple[str, str]:
+    def simple(self, my_string: str = None, my_number: int = None, my_level_three_message: sandbox__test__beta_dc.BetaMessage = None) -> typing.Tuple[str, str]:
         return self._forward_to_grpc(sandbox__test__delta_dc.DeltaMessage, self.stub.Simple, my_string, my_number, my_level_three_message)
 
-    def nested(self, simple_field: str = None, message_field: sandbox__test__rainbow_dc.SubMessage = None, simple_list: List[str] = None, message_list: List[sandbox__test__rainbow_dc.SubMessage] = None, simple_map: Dict[str, str] = None, message_map: Dict[str, sandbox__test__rainbow_dc.SubMessage] = None) -> Tuple[str, int, sandbox__test__alpha_dc.AlphaMessage]:
+    def nested(self, simple_field: str = None, message_field: sandbox__test__rainbow_dc.SubMessage = None, simple_list: typing.List[str] = None, message_list: typing.List[sandbox__test__rainbow_dc.SubMessage] = None, simple_map: typing.Dict[str, str] = None, message_map: typing.Dict[str, sandbox__test__rainbow_dc.SubMessage] = None) -> typing.Tuple[str, int, sandbox__test__alpha_dc.AlphaMessage]:
         return self._forward_to_grpc(sandbox__test__rainbow_dc.RainbowMessage, self.stub.Nested, simple_field, message_field, simple_list, message_list, simple_map, message_map)
 
-    def renest(self, my_int: int = None, my_string: str = None, my_message: sandbox__test__nested_dc.OuterMessage.InnerMessage = None) -> Tuple[str, str]:
+    def renest(self, my_int: int = None, my_string: str = None, my_message: sandbox__test__nested_dc.OuterMessage.InnerMessage = None) -> typing.Tuple[str, str]:
         return self._forward_to_grpc(sandbox__test__nested_dc.OuterMessage, self.stub.Renest, my_int, my_string, my_message)
 
-    def timestamp_in(self, my_timestamp: datetime.datetime = None, my_timestamp_list: List[datetime.datetime] = None, my_timestamp_map: Dict[str, datetime.datetime] = None) -> Tuple[str, int]:
+    def timestamp_in(self, my_timestamp: datetime.datetime = None, my_timestamp_list: typing.List[datetime.datetime] = None, my_timestamp_map: typing.Dict[str, datetime.datetime] = None) -> typing.Tuple[str, int]:
         return self._forward_to_grpc(sandbox__test__rainbow_dc.TimestampMessage, self.stub.TimestampIn, my_timestamp, my_timestamp_list, my_timestamp_map)
 
-    def timestamp_out(self, my_string: str = None, my_number: int = None) -> Tuple[int, int]:
+    def timestamp_out(self, my_string: str = None, my_number: int = None) -> typing.Tuple[int, int]:
         return self._forward_to_grpc(sandbox__test__alpha_dc.AlphaMessage, self.stub.TimestampOut, my_string, my_number)
 
-    def any_in(self, type_url: str = None, value: bytes = None) -> Tuple[str, int]:
+    def any_in(self, type_url: str = None, value: bytes = None) -> typing.Tuple[str, int]:
         return self._forward_to_grpc(None, self.stub.AnyIn, type_url, value)
 
-    def any_out(self, my_string: str = None, my_number: int = None) -> Tuple[str, bytes]:
+    def any_out(self, my_string: str = None, my_number: int = None) -> typing.Tuple[str, bytes]:
         return self._forward_to_grpc(sandbox__test__alpha_dc.AlphaMessage, self.stub.AnyOut, my_string, my_number)

--- a/tests/res/expected/sandbox/test/service_with_oneof_api.py
+++ b/tests/res/expected/sandbox/test/service_with_oneof_api.py
@@ -6,7 +6,7 @@ __all__ = [
     'SimpleOneOfServiceInterface',
 ]
 import datetime
-from typing import *
+import typing
 from protoplasm import plasm
 
 from sandbox.test import service_with_oneof_dc as dc
@@ -19,6 +19,6 @@ log = logging.getLogger(__name__)
 class SimpleOneOfServiceInterface:
     __servicer_cls__ = SimpleOneOfServiceGrpcServicer
 
-    def hello_again(self, greeting: str = None) -> Tuple[str, int]:
+    def hello_again(self, greeting: str = None) -> typing.Tuple[str, int]:
         raise plasm.Unimplemented()
 

--- a/tests/res/expected/sandbox/test/service_with_oneof_dc.py
+++ b/tests/res/expected/sandbox/test/service_with_oneof_dc.py
@@ -10,7 +10,7 @@ __all__ = [
 import dataclasses
 import datetime
 import enum
-from typing import *
+import typing
 from protoplasm.casting import dictators
 from protoplasm import plasm
 

--- a/tests/res/expected/sandbox/test/service_with_oneof_grpc_receiver.py
+++ b/tests/res/expected/sandbox/test/service_with_oneof_grpc_receiver.py
@@ -5,12 +5,13 @@
 __all__ = [
     'SimpleOneOfServiceGrpcServicer',
 ]
-from typing import *
+import datetime
+import typing
 from protoplasm import plasm
 from sandbox.test import service_with_oneof_dc as dc
 from sandbox.test import service_with_oneof_pb2 as pb2
 from sandbox.test import service_with_oneof_pb2_grpc as pb2_grpc
-if TYPE_CHECKING:
+if typing.TYPE_CHECKING:
     from grpc import ServicerContext
     from sandbox.test import service_with_oneof_api as api
 

--- a/tests/res/expected/sandbox/test/service_with_oneof_grpc_sender.py
+++ b/tests/res/expected/sandbox/test/service_with_oneof_grpc_sender.py
@@ -6,13 +6,14 @@ from __future__ import annotations
 __all__ = [
     'SimpleOneOfService',
 ]
-from typing import *
+import datetime
+import typing
 from protoplasm import plasm
 from sandbox.test import service_with_oneof_dc as dc
 from sandbox.test import service_with_oneof_pb2_grpc as pb2_grpc
 from sandbox.test.service_with_oneof_api import *
 
-if TYPE_CHECKING:
+if typing.TYPE_CHECKING:
     from grpc import ChannelCredentials
 
 import logging
@@ -20,8 +21,8 @@ log = logging.getLogger(__name__)
 
 
 class SimpleOneOfService(plasm.BaseGrpcClientImplementation, SimpleOneOfServiceInterface):
-    def __init__(self, grpc_host: str = 'localhost:50051', credentials: Optional[Union[bool, 'ChannelCredentials']] = None, options: Optional[Dict] = None, *args, **kwargs):
+    def __init__(self, grpc_host: str = 'localhost:50051', credentials: typing.Optional[typing.Union[bool, 'ChannelCredentials']] = None, options: typing.Optional[typing.Dict] = None, *args, **kwargs):
         super().__init__(pb2_grpc.SimpleOneOfServiceStub, grpc_host, credentials, options, *args, **kwargs)
 
-    def hello_again(self, greeting: str = None) -> Tuple[str, int]:
+    def hello_again(self, greeting: str = None) -> typing.Tuple[str, int]:
         return self._forward_to_grpc(dc.HelloAgainRequest, self.stub.HelloAgain, greeting)

--- a/tests/res/expected/sandbox/test/test_dc.py
+++ b/tests/res/expected/sandbox/test/test_dc.py
@@ -16,7 +16,7 @@ __all__ = [
 import dataclasses
 import datetime
 import enum
-from typing import *
+import typing
 from protoplasm.casting import dictators
 from protoplasm import plasm
 
@@ -49,38 +49,38 @@ class Simple(plasm.DataclassBase):
 @dataclasses.dataclass
 class SimpleList(plasm.DataclassBase):
     __proto_cls__ = pb2.SimpleList
-    my_string_list: List[str] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.BaseDictator, 'is_list': True})
-    my_float_list: List[float] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.BaseDictator, 'is_list': True})
-    my_double_list: List[float] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.BaseDictator, 'is_list': True})
-    my_int32_list: List[int] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.BaseDictator, 'is_list': True})
-    my_int64_list: List[int] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.LongDictator, 'is_list': True})
-    my_uint32_list: List[int] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.BaseDictator, 'is_list': True})
-    my_uint64_list: List[int] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.LongDictator, 'is_list': True})
-    my_sint32_list: List[int] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.BaseDictator, 'is_list': True})
-    my_sint64_list: List[int] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.LongDictator, 'is_list': True})
-    my_fixed32_list: List[int] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.BaseDictator, 'is_list': True})
-    my_fixed64_list: List[int] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.LongDictator, 'is_list': True})
-    my_sfixed32_list: List[int] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.BaseDictator, 'is_list': True})
-    my_sfixed64_list: List[int] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.LongDictator, 'is_list': True})
-    my_bool_list: List[bool] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.BaseDictator, 'is_list': True})
-    my_bytes_list: List[bytes] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.ByteDictator, 'is_list': True})
+    my_string_list: typing.List[str] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.BaseDictator, 'is_list': True})
+    my_float_list: typing.List[float] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.BaseDictator, 'is_list': True})
+    my_double_list: typing.List[float] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.BaseDictator, 'is_list': True})
+    my_int32_list: typing.List[int] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.BaseDictator, 'is_list': True})
+    my_int64_list: typing.List[int] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.LongDictator, 'is_list': True})
+    my_uint32_list: typing.List[int] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.BaseDictator, 'is_list': True})
+    my_uint64_list: typing.List[int] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.LongDictator, 'is_list': True})
+    my_sint32_list: typing.List[int] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.BaseDictator, 'is_list': True})
+    my_sint64_list: typing.List[int] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.LongDictator, 'is_list': True})
+    my_fixed32_list: typing.List[int] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.BaseDictator, 'is_list': True})
+    my_fixed64_list: typing.List[int] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.LongDictator, 'is_list': True})
+    my_sfixed32_list: typing.List[int] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.BaseDictator, 'is_list': True})
+    my_sfixed64_list: typing.List[int] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.LongDictator, 'is_list': True})
+    my_bool_list: typing.List[bool] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.BaseDictator, 'is_list': True})
+    my_bytes_list: typing.List[bytes] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.ByteDictator, 'is_list': True})
 
 
 @dataclasses.dataclass
 class SimpleMap(plasm.DataclassBase):
     __proto_cls__ = pb2.SimpleMap
-    my_string_map: Dict[str, str] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True})
-    my_int32_map: Dict[int, int] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True})
-    my_int64_map: Dict[int, int] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.LongDictator, 'is_map': True})
-    my_uint32_map: Dict[int, int] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True})
-    my_uint64_map: Dict[int, int] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.LongDictator, 'is_map': True})
-    my_sint32_map: Dict[int, int] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True})
-    my_sint64_map: Dict[int, int] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.LongDictator, 'is_map': True})
-    my_fixed32_map: Dict[int, int] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True})
-    my_fixed64_map: Dict[int, int] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.LongDictator, 'is_map': True})
-    my_sfixed32_map: Dict[int, int] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True})
-    my_sfixed64_map: Dict[int, int] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.LongDictator, 'is_map': True})
-    my_bool_map: Dict[bool, bool] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True})
+    my_string_map: typing.Dict[str, str] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True})
+    my_int32_map: typing.Dict[int, int] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True})
+    my_int64_map: typing.Dict[int, int] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.LongDictator, 'is_map': True})
+    my_uint32_map: typing.Dict[int, int] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True})
+    my_uint64_map: typing.Dict[int, int] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.LongDictator, 'is_map': True})
+    my_sint32_map: typing.Dict[int, int] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True})
+    my_sint64_map: typing.Dict[int, int] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.LongDictator, 'is_map': True})
+    my_fixed32_map: typing.Dict[int, int] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True})
+    my_fixed64_map: typing.Dict[int, int] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.LongDictator, 'is_map': True})
+    my_sfixed32_map: typing.Dict[int, int] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True})
+    my_sfixed64_map: typing.Dict[int, int] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.LongDictator, 'is_map': True})
+    my_bool_map: typing.Dict[bool, bool] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True})
 
 
 @dataclasses.dataclass
@@ -98,14 +98,14 @@ class NestedDude(plasm.DataclassBase):
 @dataclasses.dataclass
 class NestedList(plasm.DataclassBase):
     __proto_cls__ = pb2.NestedList
-    my_simple_list: List[Simple] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.BaseDictator, 'is_list': True, 'is_obj': True})
+    my_simple_list: typing.List[Simple] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.BaseDictator, 'is_list': True, 'is_obj': True})
 
 
 @dataclasses.dataclass
 class NestedMap(plasm.DataclassBase):
     __proto_cls__ = pb2.NestedMap
-    my_string_simple_map: Dict[str, Simple] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True, 'is_obj': True})
-    my_int32_simple_map: Dict[int, Simple] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True, 'is_obj': True})
+    my_string_simple_map: typing.Dict[str, Simple] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True, 'is_obj': True})
+    my_int32_simple_map: typing.Dict[int, Simple] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True, 'is_obj': True})
 
 
 @dataclasses.dataclass
@@ -113,6 +113,6 @@ class VeryNestedDude(plasm.DataclassBase):
     __proto_cls__ = pb2.VeryNestedDude
     my_nested_dude: NestedDude = dataclasses.field(default=None, metadata={'dictator': dictators.BaseDictator, 'is_obj': True})
     my_non_nested_simple: Simple = dataclasses.field(default=None, metadata={'dictator': dictators.BaseDictator, 'is_obj': True})
-    my_list_of_lists: List[NestedList] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.BaseDictator, 'is_list': True, 'is_obj': True})
+    my_list_of_lists: typing.List[NestedList] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.BaseDictator, 'is_list': True, 'is_obj': True})
 
 

--- a/tests/res/expected/sandbox/test/timeduration_dc.py
+++ b/tests/res/expected/sandbox/test/timeduration_dc.py
@@ -9,7 +9,7 @@ __all__ = [
 import dataclasses
 import datetime
 import enum
-from typing import *
+import typing
 from protoplasm.casting import dictators
 from protoplasm import plasm
 
@@ -23,7 +23,7 @@ log = logging.getLogger(__name__)
 class DurationMessage(plasm.DataclassBase):
     __proto_cls__ = pb2.DurationMessage
     my_duration: datetime.timedelta = dataclasses.field(default=None, metadata={'dictator': dictators.DurationDictator})
-    my_duration_list: List[datetime.timedelta] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.DurationDictator, 'is_list': True})
-    my_duration_map: Dict[str, datetime.timedelta] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.DurationDictator, 'is_map': True})
+    my_duration_list: typing.List[datetime.timedelta] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.DurationDictator, 'is_list': True})
+    my_duration_map: typing.Dict[str, datetime.timedelta] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.DurationDictator, 'is_map': True})
 
 

--- a/tests/test_zdataclassbuilder.py
+++ b/tests/test_zdataclassbuilder.py
@@ -101,10 +101,10 @@ class ProtoFieldTest(unittest.TestCase):
         self.assertFalse(proto_field.is_enum())
 
         self.assertEqual('simple_list', proto_field.py_name())
-        self.assertEqual('List[str]', proto_field.get_type_hint())
+        self.assertEqual('typing.List[str]', proto_field.get_type_hint())
         self.assertEqual('BaseDictator', proto_field.get_dictator_name())
         self.assertEqual("'dictator': dictators.BaseDictator, 'is_list': True", proto_field.get_metadata())
-        self.assertEqual("simple_list: List[str] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.BaseDictator, 'is_list': True})", proto_field.render_py())
+        self.assertEqual("simple_list: typing.List[str] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.BaseDictator, 'is_list': True})", proto_field.render_py())
 
     def test_rainbow_message_list(self):
         from sandbox.test import rainbow_pb2
@@ -125,10 +125,10 @@ class ProtoFieldTest(unittest.TestCase):
         self.assertFalse(proto_field.is_enum())
 
         self.assertEqual('message_list', proto_field.py_name())
-        self.assertEqual('List[SubMessage]', proto_field.get_type_hint())
+        self.assertEqual('typing.List[SubMessage]', proto_field.get_type_hint())
         self.assertEqual('BaseDictator', proto_field.get_dictator_name())
         self.assertEqual("'dictator': dictators.BaseDictator, 'is_list': True, 'is_obj': True", proto_field.get_metadata())
-        self.assertEqual("message_list: List[SubMessage] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.BaseDictator, 'is_list': True, 'is_obj': True})", proto_field.render_py())
+        self.assertEqual("message_list: typing.List[SubMessage] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.BaseDictator, 'is_list': True, 'is_obj': True})", proto_field.render_py())
 
     def test_rainbow_simple_map(self):
         from sandbox.test import rainbow_pb2
@@ -149,10 +149,10 @@ class ProtoFieldTest(unittest.TestCase):
         self.assertFalse(proto_field.is_enum())
 
         self.assertEqual('simple_map', proto_field.py_name())
-        self.assertEqual('Dict[str, str]', proto_field.get_type_hint())
+        self.assertEqual('typing.Dict[str, str]', proto_field.get_type_hint())
         self.assertEqual('BaseDictator', proto_field.get_dictator_name())
         self.assertEqual("'dictator': dictators.BaseDictator, 'is_map': True", proto_field.get_metadata())
-        self.assertEqual("simple_map: Dict[str, str] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True})", proto_field.render_py())
+        self.assertEqual("simple_map: typing.Dict[str, str] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True})", proto_field.render_py())
 
     def test_rainbow_message_map(self):
         from sandbox.test import rainbow_pb2
@@ -173,10 +173,10 @@ class ProtoFieldTest(unittest.TestCase):
         self.assertFalse(proto_field.is_enum())
 
         self.assertEqual('message_map', proto_field.py_name())
-        self.assertEqual('Dict[str, SubMessage]', proto_field.get_type_hint())
+        self.assertEqual('typing.Dict[str, SubMessage]', proto_field.get_type_hint())
         self.assertEqual('BaseDictator', proto_field.get_dictator_name())
         self.assertEqual("'dictator': dictators.BaseDictator, 'is_map': True, 'is_obj': True", proto_field.get_metadata())
-        self.assertEqual("message_map: Dict[str, SubMessage] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True, 'is_obj': True})", proto_field.render_py())
+        self.assertEqual("message_map: typing.Dict[str, SubMessage] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True, 'is_obj': True})", proto_field.render_py())
 
     def test_timestamp(self):
         from sandbox.test import rainbow_pb2
@@ -221,10 +221,10 @@ class ProtoFieldTest(unittest.TestCase):
         self.assertFalse(proto_field.is_enum())
 
         self.assertEqual('my_timestamp_list', proto_field.py_name())
-        self.assertEqual('List[datetime.datetime]', proto_field.get_type_hint())
+        self.assertEqual('typing.List[datetime.datetime]', proto_field.get_type_hint())
         self.assertEqual('TimestampDictator', proto_field.get_dictator_name())
         self.assertEqual("'dictator': dictators.TimestampDictator, 'is_list': True", proto_field.get_metadata())
-        self.assertEqual("my_timestamp_list: List[datetime.datetime] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.TimestampDictator, 'is_list': True})", proto_field.render_py())
+        self.assertEqual("my_timestamp_list: typing.List[datetime.datetime] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.TimestampDictator, 'is_list': True})", proto_field.render_py())
 
     def test_timestamp_map(self):
         from sandbox.test import rainbow_pb2
@@ -245,10 +245,10 @@ class ProtoFieldTest(unittest.TestCase):
         self.assertFalse(proto_field.is_enum())
 
         self.assertEqual('my_timestamp_map', proto_field.py_name())
-        self.assertEqual('Dict[str, datetime.datetime]', proto_field.get_type_hint())
+        self.assertEqual('typing.Dict[str, datetime.datetime]', proto_field.get_type_hint())
         self.assertEqual('TimestampDictator', proto_field.get_dictator_name())
         self.assertEqual("'dictator': dictators.TimestampDictator, 'is_map': True", proto_field.get_metadata())
-        self.assertEqual("my_timestamp_map: Dict[str, datetime.datetime] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.TimestampDictator, 'is_map': True})", proto_field.render_py())
+        self.assertEqual("my_timestamp_map: typing.Dict[str, datetime.datetime] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.TimestampDictator, 'is_map': True})", proto_field.render_py())
 
     def test_bytes(self):
         from sandbox.test import rainbow_pb2
@@ -292,10 +292,10 @@ class ProtoFieldTest(unittest.TestCase):
         self.assertFalse(proto_field.is_enum())
 
         self.assertEqual('my_bytes_list', proto_field.py_name())
-        self.assertEqual('List[bytes]', proto_field.get_type_hint())
+        self.assertEqual('typing.List[bytes]', proto_field.get_type_hint())
         self.assertEqual('ByteDictator', proto_field.get_dictator_name())
         self.assertEqual("'dictator': dictators.ByteDictator, 'is_list': True", proto_field.get_metadata())
-        self.assertEqual("my_bytes_list: List[bytes] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.ByteDictator, 'is_list': True})", proto_field.render_py())
+        self.assertEqual("my_bytes_list: typing.List[bytes] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.ByteDictator, 'is_list': True})", proto_field.render_py())
 
     def test_bytes_map(self):
         from sandbox.test import rainbow_pb2
@@ -316,10 +316,10 @@ class ProtoFieldTest(unittest.TestCase):
         self.assertFalse(proto_field.is_enum())
 
         self.assertEqual('my_bytes_map', proto_field.py_name())
-        self.assertEqual('Dict[str, bytes]', proto_field.get_type_hint())
+        self.assertEqual('typing.Dict[str, bytes]', proto_field.get_type_hint())
         self.assertEqual('ByteDictator', proto_field.get_dictator_name())
         self.assertEqual("'dictator': dictators.ByteDictator, 'is_map': True", proto_field.get_metadata())
-        self.assertEqual("my_bytes_map: Dict[str, bytes] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.ByteDictator, 'is_map': True})", proto_field.render_py())
+        self.assertEqual("my_bytes_map: typing.Dict[str, bytes] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.ByteDictator, 'is_map': True})", proto_field.render_py())
 
     def test_all_types(self):
         from sandbox.test import rainbow_pb2
@@ -352,21 +352,21 @@ class AllTypes(plasm.DataclassBase):
         expected = """@dataclasses.dataclass
 class AllTypesList(plasm.DataclassBase):
     __proto_cls__ = pb2.AllTypesList
-    my_string_list: List[str] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.BaseDictator, 'is_list': True})
-    my_float_list: List[float] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.BaseDictator, 'is_list': True})
-    my_double_list: List[float] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.BaseDictator, 'is_list': True})
-    my_int32_list: List[int] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.BaseDictator, 'is_list': True})
-    my_int64_list: List[int] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.LongDictator, 'is_list': True})
-    my_uint32_list: List[int] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.BaseDictator, 'is_list': True})
-    my_uint64_list: List[int] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.LongDictator, 'is_list': True})
-    my_sint32_list: List[int] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.BaseDictator, 'is_list': True})
-    my_sint64_list: List[int] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.LongDictator, 'is_list': True})
-    my_fixed32_list: List[int] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.BaseDictator, 'is_list': True})
-    my_fixed64_list: List[int] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.LongDictator, 'is_list': True})
-    my_sfixed32_list: List[int] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.BaseDictator, 'is_list': True})
-    my_sfixed64_list: List[int] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.LongDictator, 'is_list': True})
-    my_bool_list: List[bool] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.BaseDictator, 'is_list': True})
-    my_bytes_list: List[bytes] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.ByteDictator, 'is_list': True})"""
+    my_string_list: typing.List[str] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.BaseDictator, 'is_list': True})
+    my_float_list: typing.List[float] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.BaseDictator, 'is_list': True})
+    my_double_list: typing.List[float] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.BaseDictator, 'is_list': True})
+    my_int32_list: typing.List[int] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.BaseDictator, 'is_list': True})
+    my_int64_list: typing.List[int] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.LongDictator, 'is_list': True})
+    my_uint32_list: typing.List[int] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.BaseDictator, 'is_list': True})
+    my_uint64_list: typing.List[int] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.LongDictator, 'is_list': True})
+    my_sint32_list: typing.List[int] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.BaseDictator, 'is_list': True})
+    my_sint64_list: typing.List[int] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.LongDictator, 'is_list': True})
+    my_fixed32_list: typing.List[int] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.BaseDictator, 'is_list': True})
+    my_fixed64_list: typing.List[int] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.LongDictator, 'is_list': True})
+    my_sfixed32_list: typing.List[int] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.BaseDictator, 'is_list': True})
+    my_sfixed64_list: typing.List[int] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.LongDictator, 'is_list': True})
+    my_bool_list: typing.List[bool] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.BaseDictator, 'is_list': True})
+    my_bytes_list: typing.List[bytes] = dataclasses.field(default_factory=list, metadata={'dictator': dictators.ByteDictator, 'is_list': True})"""
         self.assertEqual(expected, class_string)
 
     def test_all_types_map(self):
@@ -376,18 +376,18 @@ class AllTypesList(plasm.DataclassBase):
         expected = """@dataclasses.dataclass
 class AllTypesMap(plasm.DataclassBase):
     __proto_cls__ = pb2.AllTypesMap
-    my_string_map: Dict[str, str] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True})
-    my_int32_map: Dict[int, int] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True})
-    my_int64_map: Dict[int, int] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.LongDictator, 'is_map': True})
-    my_uint32_map: Dict[int, int] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True})
-    my_uint64_map: Dict[int, int] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.LongDictator, 'is_map': True})
-    my_sint32_map: Dict[int, int] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True})
-    my_sint64_map: Dict[int, int] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.LongDictator, 'is_map': True})
-    my_fixed32_map: Dict[int, int] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True})
-    my_fixed64_map: Dict[int, int] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.LongDictator, 'is_map': True})
-    my_sfixed32_map: Dict[int, int] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True})
-    my_sfixed64_map: Dict[int, int] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.LongDictator, 'is_map': True})
-    my_bool_map: Dict[bool, bool] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True})"""
+    my_string_map: typing.Dict[str, str] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True})
+    my_int32_map: typing.Dict[int, int] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True})
+    my_int64_map: typing.Dict[int, int] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.LongDictator, 'is_map': True})
+    my_uint32_map: typing.Dict[int, int] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True})
+    my_uint64_map: typing.Dict[int, int] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.LongDictator, 'is_map': True})
+    my_sint32_map: typing.Dict[int, int] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True})
+    my_sint64_map: typing.Dict[int, int] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.LongDictator, 'is_map': True})
+    my_fixed32_map: typing.Dict[int, int] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True})
+    my_fixed64_map: typing.Dict[int, int] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.LongDictator, 'is_map': True})
+    my_sfixed32_map: typing.Dict[int, int] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True})
+    my_sfixed64_map: typing.Dict[int, int] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.LongDictator, 'is_map': True})
+    my_bool_map: typing.Dict[bool, bool] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True})"""
         self.assertEqual(expected, class_string)
 
     def test_all_types_nested_map(self):
@@ -397,18 +397,18 @@ class AllTypesMap(plasm.DataclassBase):
         expected = """@dataclasses.dataclass
 class AllTypesNestedMap(plasm.DataclassBase):
     __proto_cls__ = pb2.AllTypesNestedMap
-    my_string_map: Dict[str, SubMessage] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True, 'is_obj': True})
-    my_int32_map: Dict[int, SubMessage] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True, 'is_obj': True})
-    my_int64_map: Dict[int, SubMessage] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True, 'is_obj': True})
-    my_uint32_map: Dict[int, SubMessage] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True, 'is_obj': True})
-    my_uint64_map: Dict[int, SubMessage] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True, 'is_obj': True})
-    my_sint32_map: Dict[int, SubMessage] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True, 'is_obj': True})
-    my_sint64_map: Dict[int, SubMessage] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True, 'is_obj': True})
-    my_fixed32_map: Dict[int, SubMessage] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True, 'is_obj': True})
-    my_fixed64_map: Dict[int, SubMessage] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True, 'is_obj': True})
-    my_sfixed32_map: Dict[int, SubMessage] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True, 'is_obj': True})
-    my_sfixed64_map: Dict[int, SubMessage] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True, 'is_obj': True})
-    my_bool_map: Dict[bool, SubMessage] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True, 'is_obj': True})"""
+    my_string_map: typing.Dict[str, SubMessage] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True, 'is_obj': True})
+    my_int32_map: typing.Dict[int, SubMessage] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True, 'is_obj': True})
+    my_int64_map: typing.Dict[int, SubMessage] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True, 'is_obj': True})
+    my_uint32_map: typing.Dict[int, SubMessage] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True, 'is_obj': True})
+    my_uint64_map: typing.Dict[int, SubMessage] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True, 'is_obj': True})
+    my_sint32_map: typing.Dict[int, SubMessage] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True, 'is_obj': True})
+    my_sint64_map: typing.Dict[int, SubMessage] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True, 'is_obj': True})
+    my_fixed32_map: typing.Dict[int, SubMessage] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True, 'is_obj': True})
+    my_fixed64_map: typing.Dict[int, SubMessage] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True, 'is_obj': True})
+    my_sfixed32_map: typing.Dict[int, SubMessage] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True, 'is_obj': True})
+    my_sfixed64_map: typing.Dict[int, SubMessage] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True, 'is_obj': True})
+    my_bool_map: typing.Dict[bool, SubMessage] = dataclasses.field(default_factory=dict, metadata={'dictator': dictators.BaseDictator, 'is_map': True, 'is_obj': True})"""
         self.assertEqual(expected, class_string)
 
     def test_duration(self):
@@ -448,7 +448,7 @@ class AllTypesNestedMap(plasm.DataclassBase):
         proto_class = neobuilder.generators.symbols.dataclass.ProtoClass(timeduration_pb2.DurationMessage.DESCRIPTOR,
                                                                          neobuilder.generators.symbols.modules.ProtoModule(timeduration_pb2))
         exp_field = 'my_duration_list'
-        exp_type_hint = 'List[datetime.timedelta]'
+        exp_type_hint = 'typing.List[datetime.timedelta]'
         exp_dictator = 'DurationDictator'
         exp_meta = f"'dictator': dictators.{exp_dictator}, 'is_list': True"
         exp_default = 'default_factory=list'
@@ -481,7 +481,7 @@ class AllTypesNestedMap(plasm.DataclassBase):
         proto_class = neobuilder.generators.symbols.dataclass.ProtoClass(timeduration_pb2.DurationMessage.DESCRIPTOR,
                                                                          neobuilder.generators.symbols.modules.ProtoModule(timeduration_pb2))
         exp_field = 'my_duration_map'
-        exp_type_hint = 'Dict[str, datetime.timedelta]'
+        exp_type_hint = 'typing.Dict[str, datetime.timedelta]'
         exp_dictator = 'DurationDictator'
         exp_meta = f"'dictator': dictators.{exp_dictator}, 'is_map': True"
         exp_default = 'default_factory=dict'
@@ -565,7 +565,7 @@ class ProtoAnyFieldTest(unittest.TestCase):
         proto_class = neobuilder.generators.symbols.dataclass.ProtoClass(anytest_pb2.AnyMessage.DESCRIPTOR,
                                                                          neobuilder.generators.symbols.modules.ProtoModule(anytest_pb2))
         exp_field = 'my_any_list'
-        exp_type_hint = 'List[plasm.DataclassBase]'
+        exp_type_hint = 'typing.List[plasm.DataclassBase]'
         exp_dictator = 'AnyDictator'
         exp_meta = f"'dictator': dictators.{exp_dictator}, 'is_list': True"
         exp_default = 'default_factory=list'
@@ -599,7 +599,7 @@ class ProtoAnyFieldTest(unittest.TestCase):
         proto_class = neobuilder.generators.symbols.dataclass.ProtoClass(anytest_pb2.AnyMessage.DESCRIPTOR,
                                                                          neobuilder.generators.symbols.modules.ProtoModule(anytest_pb2))
         exp_field = 'my_any_map'
-        exp_type_hint = 'Dict[str, plasm.DataclassBase]'
+        exp_type_hint = 'typing.Dict[str, plasm.DataclassBase]'
         exp_dictator = 'AnyDictator'
         exp_meta = f"'dictator': dictators.{exp_dictator}, 'is_map': True"
         exp_default = 'default_factory=dict'
@@ -744,7 +744,7 @@ DEFAULT = ExternalAliasEnum(0)""", proto_enum.render_py_consts().strip())
         proto_class = proto_module.message_map['WithExternalEnum']
         exp_field = 'my_enum_list'
         exp_dictator = 'EnumDictator'
-        exp_type_hint = 'List[ExternalEnum]'
+        exp_type_hint = 'typing.List[ExternalEnum]'
         exp_meta = f"'dictator': dictators.{exp_dictator}, 'is_list': True, 'is_enum': True"
         exp_default = 'default_factory=list'
 
@@ -775,7 +775,7 @@ DEFAULT = ExternalAliasEnum(0)""", proto_enum.render_py_consts().strip())
         proto_class = proto_module.message_map['WithExternalEnum']
         exp_field = 'my_alias_enum_list'
         exp_dictator = 'EnumDictator'
-        exp_type_hint = 'List[ExternalAliasEnum]'
+        exp_type_hint = 'typing.List[ExternalAliasEnum]'
         exp_meta = f"'dictator': dictators.{exp_dictator}, 'is_list': True, 'is_enum': True"
         exp_default = 'default_factory=list'
 
@@ -806,7 +806,7 @@ DEFAULT = ExternalAliasEnum(0)""", proto_enum.render_py_consts().strip())
         proto_class = proto_module.message_map['WithExternalEnum']
         exp_field = 'my_enum_map'
         exp_dictator = 'EnumDictator'
-        exp_type_hint = 'Dict[str, ExternalEnum]'
+        exp_type_hint = 'typing.Dict[str, ExternalEnum]'
         exp_meta = f"'dictator': dictators.{exp_dictator}, 'is_map': True, 'is_enum': True"
         exp_default = 'default_factory=dict'
 
@@ -837,7 +837,7 @@ DEFAULT = ExternalAliasEnum(0)""", proto_enum.render_py_consts().strip())
         proto_class = proto_module.message_map['WithExternalEnum']
         exp_field = 'my_alias_enum_map'
         exp_dictator = 'EnumDictator'
-        exp_type_hint = 'Dict[str, ExternalAliasEnum]'
+        exp_type_hint = 'typing.Dict[str, ExternalAliasEnum]'
         exp_meta = f"'dictator': dictators.{exp_dictator}, 'is_map': True, 'is_enum': True"
         exp_default = 'default_factory=dict'
 
@@ -1006,7 +1006,7 @@ DEFAULT = InternalAliasEnum(0)""", proto_enum.render_py_consts().strip())
         proto_class = proto_module.message_map['WithInternalEnum']
 
         exp_field = 'my_internal_enum_list'
-        exp_type_hint = 'List[WithInternalEnum.InternalEnum]'
+        exp_type_hint = 'typing.List[WithInternalEnum.InternalEnum]'
         exp_dictator = 'EnumDictator'
         exp_meta = f"'dictator': dictators.{exp_dictator}, 'is_list': True, 'is_enum': True"
         exp_default = 'default_factory=list'
@@ -1038,7 +1038,7 @@ DEFAULT = InternalAliasEnum(0)""", proto_enum.render_py_consts().strip())
         proto_class = proto_module.message_map['WithInternalEnum']
 
         exp_field = 'my_internal_alias_enum_list'
-        exp_type_hint = 'List[WithInternalEnum.InternalAliasEnum]'
+        exp_type_hint = 'typing.List[WithInternalEnum.InternalAliasEnum]'
         exp_dictator = 'EnumDictator'
         exp_meta = f"'dictator': dictators.{exp_dictator}, 'is_list': True, 'is_enum': True"
         exp_default = 'default_factory=list'
@@ -1070,7 +1070,7 @@ DEFAULT = InternalAliasEnum(0)""", proto_enum.render_py_consts().strip())
         proto_class = proto_module.message_map['WithInternalEnum']
 
         exp_field = 'my_internal_enum_map'
-        exp_type_hint = 'Dict[str, WithInternalEnum.InternalEnum]'
+        exp_type_hint = 'typing.Dict[str, WithInternalEnum.InternalEnum]'
         exp_dictator = 'EnumDictator'
         exp_meta = f"'dictator': dictators.{exp_dictator}, 'is_map': True, 'is_enum': True"
         exp_default = 'default_factory=dict'
@@ -1102,7 +1102,7 @@ DEFAULT = InternalAliasEnum(0)""", proto_enum.render_py_consts().strip())
         proto_class = proto_module.message_map['WithInternalEnum']
 
         exp_field = 'my_internal_alias_enum_map'
-        exp_type_hint = 'Dict[str, WithInternalEnum.InternalAliasEnum]'
+        exp_type_hint = 'typing.Dict[str, WithInternalEnum.InternalAliasEnum]'
         exp_dictator = 'EnumDictator'
         exp_meta = f"'dictator': dictators.{exp_dictator}, 'is_map': True, 'is_enum': True"
         exp_default = 'default_factory=dict'


### PR DESCRIPTION
### Changed

- The line `from typing import *` in most templates to `import typing` and now references to classes an such from `typing` are explicit (i.e. `List` -> `typing.List`)

### Fixed

- Side-effects caused by `from typing import *` when messages/classes share a name of classes in the `typing` package
- Bug where `datetime` was missing from imports in gRPC senders and receivers